### PR TITLE
Add CLAUDE.md with project guide and AGENTS.md symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .replit
 .replit.nix
 .aider*
-CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,20 @@ Lynx is a self-hostable read-it-later service. The repo has two main components:
 ```
 backend/        # Go backend (PocketBase-based)
   main.go       # Entry point
-  lynx/         # Application logic (hooks, routes, etc.)
-  migrations/   # PocketBase DB migrations
+  lynx/         # Application logic (hooks, routes, middleware)
+    feeds/      # RSS feed fetching and ingestion
+    singlefile/ # SingleFile archive integration
+    summarizer/ # LLM summarization via OpenRouter
+    tagger/     # LLM tag suggestions via OpenRouter
+    url_parser/ # Article parsing and saving
+  migrations/   # PocketBase DB migrations (auto-generated)
 frontend/       # React/TypeScript frontend
-  src/          # Source files
-  public/       # Static assets
+  src/
+    components/ # Reusable UI components
+    hooks/      # React Query hooks and PocketBase auth
+    lib/        # Shared utilities (URL constants, contexts)
+    pages/      # Route-level page components
+    types/      # TypeScript types for PocketBase records
 resources/      # Docker configs, screenshots, logos
 ```
 
@@ -44,9 +53,24 @@ yarn format             # Format with prettier
 
 - The backend uses PocketBase as the database/auth layer (SQLite-backed).
 - Custom Go logic lives in `backend/lynx/` and hooks into PocketBase's event system.
+- On link creation, three async tasks fire: summarization, SingleFile archiving, and tag suggestion.
+- Feeds are fetched on a 6-hour cron schedule (`FetchFeeds`).
+- API authentication supports both PocketBase session tokens and custom API keys via `X-API-KEY` header (keys stored in `api_keys` collection, expire after 6 months).
 - The frontend communicates with PocketBase via the `pocketbase` JS SDK.
+- `VITE_POCKETBASE_URL` env var controls which PocketBase instance the frontend connects to.
 - Article parsing uses `go-readability`; RSS ingestion uses `gofeed`.
 - An optional SingleFile integration enables full-page archiving via a separate container.
+
+## Custom API Endpoints
+
+All endpoints require authentication (session or API key).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/lynx/parse_link` | Save a new link by URL |
+| POST | `/lynx/parse_feed` | Add an RSS feed |
+| POST | `/lynx/generate_api_key` | Create a new API key |
+| POST | `/lynx/link/{id}/create_archive` | Trigger SingleFile archive for a link |
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# Lynx - Claude Code Guide
+
+Lynx is a self-hostable read-it-later service. The repo has two main components:
+
+- **Backend**: Go + [PocketBase](https://github.com/pocketbase/pocketbase) (`backend/`)
+- **Frontend**: React + TypeScript + [Mantine UI](https://mantine.dev/) + Vite (`frontend/`)
+
+## Project Structure
+
+```
+backend/        # Go backend (PocketBase-based)
+  main.go       # Entry point
+  lynx/         # Application logic (hooks, routes, etc.)
+  migrations/   # PocketBase DB migrations
+frontend/       # React/TypeScript frontend
+  src/          # Source files
+  public/       # Static assets
+resources/      # Docker configs, screenshots, logos
+```
+
+## Development Commands
+
+### Backend
+```bash
+cd backend
+go build ./...          # Build
+go test ./...           # Run tests
+go run main.go serve    # Run dev server (default port 8080)
+```
+
+### Frontend
+```bash
+cd frontend
+yarn install            # Install dependencies
+yarn dev                # Start dev server
+yarn build              # Production build
+yarn test               # Run tests (vitest)
+yarn test:ci            # Type-check + run tests
+yarn lint               # Lint
+yarn format             # Format with prettier
+```
+
+## Architecture Notes
+
+- The backend uses PocketBase as the database/auth layer (SQLite-backed).
+- Custom Go logic lives in `backend/lynx/` and hooks into PocketBase's event system.
+- The frontend communicates with PocketBase via the `pocketbase` JS SDK.
+- Article parsing uses `go-readability`; RSS ingestion uses `gofeed`.
+- An optional SingleFile integration enables full-page archiving via a separate container.
+
+## Testing
+
+- Backend: standard Go tests (`go test ./...`)
+- Frontend: Vitest (`yarn test` or `yarn test:ci`)
+- CI runs both via GitHub Actions (`.github/workflows/`)

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,31 @@
+# Backend
+
+Go application built on [PocketBase](https://github.com/pocketbase/pocketbase). PocketBase handles auth, the SQLite database, file storage, and the admin UI. Custom logic hooks into PocketBase's event system.
+
+## Commands
+
+```bash
+go build ./...          # Build
+go test ./...           # Run tests
+go run main.go serve    # Run dev server (port 8080)
+```
+
+Automigrate is enabled when running via `go run` (dev mode). To create a new migration, make schema changes via the PocketBase admin UI at `localhost:8080/_` and they will be written to `migrations/` automatically.
+
+## Package Overview
+
+- **`lynx/`** — Core application logic, registered in `main.go` via `lynx.InitializePocketbase(app)`.
+  - **`lynx.go`** — Registers all routes, cron jobs, and PocketBase event hooks.
+  - **`api_key_auth_middleware.go`** — Middleware that resolves `X-API-KEY` header to a user record, enabling programmatic access without session auth.
+  - **`feeds/`** — RSS/Atom feed subscriptions. Fetches all feeds every 6 hours via cron. New feed items trigger a hook that converts them to link records.
+  - **`url_parser/`** — Fetches a URL and extracts article content using `go-readability`. Called on `POST /lynx/parse_link`.
+  - **`summarizer/`** — Calls OpenRouter to generate a summary for newly saved links. Runs asynchronously after link creation.
+  - **`tagger/`** — Calls OpenRouter to suggest tags for newly saved links. Runs asynchronously after link creation.
+  - **`singlefile/`** — Sends links to a `lynx-singlefile` container (headless Chrome) to create self-contained HTML archives. Runs asynchronously after link creation, or on-demand via `POST /lynx/link/{id}/create_archive`.
+- **`migrations/`** — Auto-generated PocketBase migrations. Do not edit by hand.
+
+## Key Patterns
+
+- **Async work**: Use `routine.FireAndForget(func() { ... })` for background tasks (summarizing, archiving, tagging) triggered by PocketBase hooks.
+- **Dependency injection for tests**: Interfaces like `Summarizer` allow replacing real implementations in tests (see `lynx_test.go`).
+- **API key expiry**: Keys expire 6 months from creation; `expires_at` is checked on every request.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,49 @@
+# Frontend
+
+React + TypeScript application built with [Vite](https://vitejs.dev/), [Mantine UI](https://mantine.dev/), and [TanStack Query](https://tanstack.com/query).
+
+## Commands
+
+```bash
+yarn install        # Install dependencies
+yarn dev            # Start dev server
+yarn build          # Production build (tsc + vite build)
+yarn test           # Run tests (vitest)
+yarn test:ci        # Type-check + run tests
+yarn lint           # ESLint
+yarn format         # Prettier
+```
+
+Set `VITE_POCKETBASE_URL` to point at a running backend (defaults to the Vite dev server proxy if unset).
+
+## Source Layout
+
+```
+src/
+  main.tsx          # App entry point, providers setup
+  App.tsx           # Root component with PocketBaseProvider
+  Router.tsx        # React Router route definitions
+  theme.ts          # Mantine theme customization
+  components/       # Reusable UI components
+  hooks/            # Data-fetching hooks (React Query) and auth
+  lib/
+    urls.ts         # Centralized route URL constants — use this for all navigation
+    CommandMenuContext.tsx  # Spotlight/command menu state
+  pages/            # One directory per route (Home, LinkViewer, Settings, etc.)
+  types/            # TypeScript types matching PocketBase collection schemas
+```
+
+## Key Patterns
+
+- **PocketBase access**: Always use the `usePocketBase()` hook to get the `pb` client and current `user`. Never instantiate `PocketBase` directly in components.
+- **Auth guard**: Use `useRequireAuth()` in pages that require login — it redirects to `/login` if the session is invalid.
+- **Data fetching**: All server state goes through TanStack Query. Hooks live in `src/hooks/`. Prefer adding a new hook file over fetching inline in components.
+- **Navigation**: Import `URLS` from `@/lib/urls` for all route paths — never hardcode strings.
+- **UI components**: Use Mantine components first. Custom components live in `src/components/`.
+
+## Collections / Data Model (key fields)
+
+- **`links`**: `title`, `url`, `excerpt`, `summary`, `header_image_url`, `hostname`, `author`, `article_date`, `last_viewed_at`, `reading_progress`, `starred_at`, `archive`, `read_time_display`, `tags` (relation), `feed` (relation)
+- **`tags`**: `name`, `user`
+- **`feeds`**: `name`, `url`, `user`
+- **`feed_items`**: intermediate records created on RSS fetch, converted to `links` asynchronously


### PR DESCRIPTION
Removes CLAUDE.md from .gitignore, adds a project guide for Claude Code
with architecture overview and development commands, and creates AGENTS.md
as a symlink to CLAUDE.md.

https://claude.ai/code/session_01NjnC7HmLyMZigp6XEtP9Hr